### PR TITLE
Add ModuleController and update module fetching logic

### DIFF
--- a/UniPortal/app/Http/Controllers/ModuleController.php
+++ b/UniPortal/app/Http/Controllers/ModuleController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Course;
+use Illuminate\Http\Request;
+
+class ModuleController extends Controller
+{
+    public function getByCourse(Course $course)
+    {
+        
+        $modules = $course->modules()->select('id', 'title')->get();
+
+       
+        return response()->json($modules);
+    }
+}

--- a/UniPortal/app/Models/Module.php
+++ b/UniPortal/app/Models/Module.php
@@ -13,6 +13,6 @@ class Module extends Model
 
     public function course()
     {
-        return $this->hasMany(Course::class);
+       return $this->belongsTo(Course::class);
     }
 }

--- a/UniPortal/resources/views/dashboards/student.blade.php
+++ b/UniPortal/resources/views/dashboards/student.blade.php
@@ -100,7 +100,7 @@
 
     {{-- Footer outside the main content container for proper color separation --}}
     @include('components.FEEfooter')
-
+  
     <script>
         const links = {
             'dashboard-link': 'dashboard-cards',

--- a/UniPortal/resources/views/lecturer/Marks/create.blade.php
+++ b/UniPortal/resources/views/lecturer/Marks/create.blade.php
@@ -67,7 +67,7 @@
         moduleSelect.disabled = true;
 
         try {
-            const response = await fetch(`/api/courses/${courseId}/modules`, {
+            const response = await fetch(`/courses/${courseId}/modules`, {
                 credentials: 'same-origin',
                 headers: {
                     'Accept': 'application/json',

--- a/UniPortal/routes/web.php
+++ b/UniPortal/routes/web.php
@@ -83,6 +83,10 @@ use App\Http\Controllers\Api\CourseModuleController;
 
 Route::get('/courses/{course}/modules', [CourseModuleController::class, 'index']);
 
+use App\Http\Controllers\ModuleController;
+
+Route::middleware('auth')->get('/courses/{course}/modules', [ModuleController::class, 'getByCourse']);
+
 
 
 


### PR DESCRIPTION
Introduced ModuleController with a getByCourse method to return modules for a given course as JSON. Updated the Module model's course relationship to belongsTo. Adjusted the lecturer marks creation view to use the new route, and registered the new route in web.php with authentication middleware.